### PR TITLE
Don't specifiy protocol for external libraries

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
     <!-- <script>document.write('<script src="http://' + (location.host || 'localhost').split(':')[0] + ':35729/livereload.js?snipver=1"></' + 'script>')</script> -->
 
     <!-- jQuery -->
-    <script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script src="http://code.jquery.com/ui/1.10.4/jquery-ui.min.js"></script>
+    <script src="//code.jquery.com/jquery-1.11.0.min.js"></script>
+    <script src="//code.jquery.com/ui/1.10.4/jquery-ui.min.js"></script>
 
     <!-- marked -->
     <script src="./js/marked.js"></script>


### PR DESCRIPTION
Fixes mixed content in Firefox >= 23 when using https.
https://blog.mozilla.org/tanvi/2013/04/10/mixed-content-blocking-enabled-in-firefox-23/
https://developer.mozilla.org/en-US/docs/Security/MixedContent
