### PR TITLE
Add caching everywhere

### DIFF
--- a/docs/how_does_it_work.md
+++ b/docs/how_does_it_work.md
@@ -20,9 +20,9 @@ Documentation defined in `sidebar.md` should be of the form:
 
 For example:
 
-    - [Documentation 1](#docs/document_1)
-    - [Documentation 2](#docs/document_2)
-    - [Documentation 3](#docs/document_3)
+    - #docs/document_1
+    - #docs/document_2
+    - #docs/document_3
 
 When you click on the link, the hash is parsed and modified in such a way it
 converts it back to the file location where the documentation is:

--- a/index.html
+++ b/index.html
@@ -3,20 +3,10 @@
 <head>
     <title>ditto</title>
 
-    <!-- jQuery -->
-    <script src="//code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script src="//code.jquery.com/ui/1.10.4/jquery-ui.min.js"></script>
-
-    <!-- marked -->
-    <script src="./js/marked.js"></script>
-
     <!-- highlight.js -->
     <link rel="stylesheet" href="./css/google_code.css">
-    <script src="./js/highlight_8.0.min.js"></script>
-    <script>hljs.initHighlightingOnLoad();</script>
 
     <!-- ditto -->
-    <script src="./js/ditto.js"></script>
     <link rel="stylesheet" href="./css/ditto.css">
 </head>
 <body>
@@ -31,20 +21,37 @@
     <div id="loading">Loading ...</div>
     <div id="error"></div>
 
+    <!-- jQuery -->
+    <script src="//code.jquery.com/jquery-1.11.0.min.js"></script>
+    <script src="//code.jquery.com/ui/1.10.4/jquery-ui.min.js"></script>
+
+    <!-- marked -->
+    <script src="./js/marked.js"></script>
+
+    <!-- highlight.js -->
+    <script src="./js/highlight_8.0.min.js"></script>
+    <script>hljs.initHighlightingOnLoad();</script>
+
+    <!-- ditto -->
+    <script src="./js/ditto.js"></script>
     <script>
-        // essential settings
-        ditto.index = "README.md",
-        ditto.sidebar_file = "sidebar.md",
+        $(function($) {
+          hljs.initHighlightingOnLoad();
 
-        // optional settings if you want github search
-        ditto.github_username = "chutsu";
-        ditto.github_repo = "ditto";
+          // essential settings
+          ditto.index = "README.md",
+          ditto.sidebar_file = "sidebar.md",
 
-        // where the docs are actually stored on github - so you can edit
-        ditto.base_url = "https://github.com/chutsu/ditto/edit/gh-pages";
+          // optional settings if you want github search
+          ditto.github_username = "chutsu";
+          ditto.github_repo = "ditto";
 
-        // run
-        ditto.run();
+          // where the docs are actually stored on github - so you can edit
+          ditto.base_url = "https://github.com/chutsu/ditto/edit/gh-pages";
+
+          // run
+          ditto.run();
+        });
     </script>
 </body>
 </html>

--- a/js/ditto.js
+++ b/js/ditto.js
@@ -1,350 +1,388 @@
-var ditto = {
-    // page elements
-    content_id: "#content",
-    sidebar_id: "#sidebar",
+$(function($) {
 
-    edit_id: "#edit",
-    back_to_top_id: "#back_to_top",
+    var ditto = {
+        content_id: $("#content"),
+        sidebar_id: $("#sidebar"),
 
-    loading_id: "#loading",
-    error_id: "#error",
+        edit_id: $("#edit"),
+        back_to_top_id: $("#back_to_top"),
 
-    search_name: "#search",
-    search_results_class: ".search_results",
-    fragments_class: ".fragments",
-    fragment_class: ".fragment",
+        loading_id: $("#loading"),
+        error_id: $("#error"),
 
-    // display elements
-    sidebar: true,
-    edit_button: true,
-    back_to_top_button: true,
-    searchbar: true,
+        search_name: $("#search"),
+        search_results_class: ".search_results",
+        fragments_class: ".fragments",
+        fragment_class: ".fragment",
 
-    // github specifics
-    github_username: null,
-    github_repo: null,
+        // display elements
+        sidebar: true,
+        edit_button: true,
+        back_to_top_button: true,
+        searchbar: true,
 
-    // initialize function
-    run: initialize
-};
+        // github specifics
+        github_username: null,
+        github_repo: null,
 
-function initialize() {
-    // initialize sidebar and buttons
-    if (ditto.sidebar) {
-        init_sidebar_section();
-    }
+        // LocalStorage id
+        storage_key: "[DITTO]",
 
-    if (ditto.back_to_top_button) {
-        init_back_to_top_button();
-    }
+        // initialize function
+        run: initialize
+    };
 
-    if (ditto.edit_button) {
-        init_edit_button();
-    }
+    var cache = {
+        present: !!window.localStorage,
 
-    // page router
-    router();
-    $(window).on('hashchange', router);
-}
+        store: function(key, value) {
+            if (!value) return;
+            return localStorage[ditto.storage_key + key] = value;
+        },
 
-function init_sidebar_section() {
-    $.get(ditto.sidebar_file, function(data) {
-        $(ditto.sidebar_id).html(marked(data));
+        fetch: function(key) {
+            return localStorage[ditto.storage_key + key];
+        }
+    };
 
-        if (ditto.searchbar) {
-            init_searchbar();
+    function initialize() {
+        // initialize sidebar and buttons
+        if (ditto.sidebar) {
+            init_sidebar_section();
         }
 
-    }, "text").fail(function() {
-        alert("Opps! can't find the sidebar file to display!");
-    });
+        if (ditto.back_to_top_button) {
+            init_back_to_top_button();
+        }
 
-}
+        if (ditto.edit_button) {
+            init_edit_button();
+        }
 
-function init_back_to_top_button() {
-    $(ditto.back_to_top_id).show();
-    $(ditto.back_to_top_id).on("click", function() {
-        $("body,html").animate({
-            scrollTop: 0
-        }, 200);
-    });
-}
+        // page router
+        router();
+        $(window).on('hashchange', router);
+    }
 
-function init_edit_button() {
-    if (ditto.base_url === null) {
-        alert("Error! You didn't set 'base_url' when calling ditto.run()!");
+    function init_sidebar_section() {
+        $.get(ditto.sidebar_file, function(data) {
+            ditto.sidebar_id.html(marked(data));
 
-    } else {
-        $(ditto.edit_id).show();
-        $(ditto.edit_id).on("click", function() {
-            var hash = location.hash.replace("#", "/");
-
-            if (hash === "") {
-                hash = "/" + ditto.index.replace(".md", "");
+            if (ditto.searchbar) {
+                init_searchbar();
             }
 
-            window.open(ditto.base_url + hash + ".md");
-            // open is better than redirecting, as the previous page history
-            // with redirect is a bit messed up
+        }, "text").fail(function() {
+            alert("Opps! can't find the sidebar file to display!");
         });
-    }
-}
-
-function init_searchbar() {
-    var sidebar = $(ditto.sidebar_id).html();
-    var match = "[ditto:searchbar]";
-
-    // html input searchbar
-    var search = "<input name='" + ditto.search_name + "'";
-    search = search + " type='search'";
-    search = search + " results='10'>";
-
-    // replace match code with a real html input search bar
-    sidebar = sidebar.replace(match, search);
-    $(ditto.sidebar_id).html(sidebar);
-
-    // add search listener
-    $("input[name=" + ditto.search_name + "]").keydown(searchbar_listener);
-}
-
-function build_text_matches_html(fragments) {
-    var html = "";
-    var class_name = ditto.fragments_class.replace(".", "");
-
-    html += "<ul class='" + class_name + "'>";
-    for (var i = 0; i < fragments.length; i++) {
-        var fragment = fragments[i].fragment.replace("/[\uE000-\uF8FF]/g", "");
-        html += "<li class='" + ditto.fragment_class.replace(".", "") + "'>";
-        html += "<pre><code> ";
-        fragment = $("#hide").text(fragment).html();
-        html += fragment;
-        html += " </code></pre></li>";
-    }
-    html += "</ul>";
-
-    return html;
-}
-
-function build_result_matches_html(matches) {
-    var html = "";
-    var class_name = ditto.search_results_class.replace(".", "");
-
-    html += "<ul class='" + class_name + "'>";
-    for (var i = 0; i < matches.length; i++) {
-        var url = matches[i].path;
-
-        if (url !== ditto.sidebar_file) {
-            var hash = "#" + url.replace(".md", "");
-            var path = window.location.origin+ "/" + hash;
-
-            // html += "<li>";
-            html += "<li class='link'>";
-            html += url;
-            // html += "<a href='" + path +"'>" + url + "</a>";
-            html += "</li>";
-
-            var match = build_text_matches_html(matches[i].text_matches);
-            html += match;
-        }
 
     }
-    html += "</ul>";
 
-    return html;
-}
-
-function display_search_results(data) {
-    var results_html = "<h1>Search Results</h1>";
-
-    console.log(data);
-
-    if (data.items.length) {
-        $(ditto.error_id).hide();
-        results_html += build_result_matches_html(data.items);
-    } else {
-        show_error("Opps.. Found no matches!");
-    }
-
-    $(ditto.content_id).html(results_html);
-    $(ditto.search_results_class + " .link").click(function(){
-        var destination = "#" + $(this).html().replace(".md", "");
-        location.hash = destination;
-    });
-}
-
-function github_search(query) {
-    if (ditto.github_username && ditto.github_repo) {
-        // build github search api url string
-        var github_api = "https://api.github.com/";
-        var search = "search/code?q=";
-        var github_repo = ditto.github_username + "/" + ditto.github_repo;
-        var search_details = "+in:file+language:markdown+repo:";
-
-        var url = github_api + search + query + search_details + github_repo;
-        var accept_header = "application/vnd.github.v3.text-match+json";
-
-        $.ajax(url, {headers: {Accept: accept_header}}).done(function(data) {
-            display_search_results(data);
+    function init_back_to_top_button() {
+        ditto.back_to_top_id.show();
+        ditto.back_to_top_id.on("click", function() {
+            $("body, html").animate({
+                scrollTop: 0
+            }, 200);
         });
     }
 
-    if (ditto.github_username == null && ditto.github_repo == null) {
-        alert("You have not set ditto.github_username and ditto.github_repo!");
-    } else if (ditto.github_username == null) {
-        alert("You have not set ditto.github_username!");
-    } else if (ditto.github_repo == null) {
-        alert("You have not set ditto.github_repo!");
-    }
-}
+    function init_edit_button() {
+        if (ditto.base_url === null) {
+            alert("Error! You didn't set 'base_url' when calling ditto.run()!");
 
-function searchbar_listener(event) {
-    if (event.which === 13) {  // when user presses ENTER in search bar
-        var q = $("input[name=" + ditto.search_name + "]").val();
-        if (q !== "") {
-            location.hash = "#search=" + q;
         } else {
-            alert("Error! Empty search query!");
+            ditto.edit_id.show();
+            ditto.edit_id.on("click", function() {
+                var hash = location.hash.replace("#", "/");
+
+                if (hash === "") {
+                    hash = "/" + ditto.index.replace(".md", "");
+                }
+
+                window.open(ditto.base_url + hash + ".md");
+                // open is better than redirecting, as the previous page history
+                // with redirect is a bit messed up
+            });
         }
     }
-}
 
-function replace_symbols(text) {
-    // replace symbols with underscore
-    return text.replace(/[&\/\\#,+=()$~%.'":*?<>{}\ \]\[]/g, "_");
-}
+    function init_searchbar() {
+        var sidebar = ditto.sidebar_id.html();
+        var match = "[ditto:searchbar]";
 
-function li_create_linkage(li_tag, header_level) {
-    // add custom id and class attributes
-    html_safe_tag = replace_symbols(li_tag.text());
-    li_tag.attr("id", html_safe_tag);
-    li_tag.attr("class", "link");
+        // html input searchbar
+        var search = "<input name='" + ditto.search_name.selector + "'";
+        search = search + " type='search'";
+        search = search + " results='10'>";
 
-    // add click listener - on click scroll to relevant header section
-    $(ditto.content_id + " li#" + li_tag.attr("id")).click(function() {
-        // scroll to relevant section
-        var header = $(
-            ditto.content_id + " h" + header_level + "." + li_tag.attr("id")
-        );
-        $('html, body').animate({
-            scrollTop: header.offset().top
-        }, 200);
+        // replace match code with a real html input search bar
+        sidebar = sidebar.replace(match, search);
+        ditto.sidebar_id.html(sidebar);
 
-        // highlight the relevant section
-        original_color = header.css("color");
-        header.animate({ color: "#ED1C24", }, 500, function() {
-            // revert back to orig color
-            $(this).animate({color: original_color}, 2500);
+        // add search listener
+        $("input[name=" + ditto.search_name.selector + "]").keydown(searchbar_listener);
+    }
+
+    function build_text_matches_html(fragments) {
+        var html = "";
+        var class_name = ditto.fragments_class.replace(".", "");
+
+        html += "<ul class='" + class_name + "'>";
+        for (var i = 0; i < fragments.length; i++) {
+            var fragment = fragments[i].fragment.replace("/[\uE000-\uF8FF]/g", "");
+            html += "<li class='" + ditto.fragment_class.replace(".", "") + "'>";
+            html += "<pre><code> ";
+            fragment = $("#hide").text(fragment).html();
+            html += fragment;
+            html += " </code></pre></li>";
+        }
+        html += "</ul>";
+
+        return html;
+    }
+
+    function build_result_matches_html(matches) {
+        var html = "";
+        var class_name = ditto.search_results_class.replace(".", "");
+
+        html += "<ul class='" + class_name + "'>";
+        for (var i = 0; i < matches.length; i++) {
+            var url = matches[i].path;
+
+            if (url !== ditto.sidebar_file) {
+                var hash = "#" + url.replace(".md", "");
+                var path = window.location.origin+ "/" + hash;
+
+                // html += "<li>";
+                html += "<li class='link'>";
+                html += url;
+                // html += "<a href='" + path +"'>" + url + "</a>";
+                html += "</li>";
+
+                var match = build_text_matches_html(matches[i].text_matches);
+                html += match;
+            }
+
+        }
+        html += "</ul>";
+
+        return html;
+    }
+
+    function display_search_results(data) {
+        var results_html = "<h1>Search Results</h1>";
+
+        if (data.items.length) {
+            hide_errors();
+            results_html += build_result_matches_html(data.items);
+        } else {
+            show_error("Opps.. Found no matches!");
+        }
+
+        ditto.content_id.html(results_html);
+        $(ditto.search_results_class + " .link").click(function(){
+            var destination = "#" + $(this).html().replace(".md", "");
+            location.hash = destination;
         });
-    });
-}
+    }
 
-function create_page_anchors() {
-    // create page anchors by matching li's to headers
-    // if there is a match, create click listeners
-    // and scroll to relevant sections
+    function github_search(query) {
+        if (ditto.github_username && ditto.github_repo) {
+            // build github search api url string
+            var github_api = "https://api.github.com/";
+            var search = "search/code?q=";
+            var github_repo = ditto.github_username + "/" + ditto.github_repo;
+            var search_details = "+in:file+language:markdown+repo:";
 
-    // go through header level 2 and 3
-    for (var i = 2; i <= 4; i++) {
-        // parse all headers
-        var headers = [];
-        $(ditto.content_id + ' h' + i).map(function() {
-            headers.push($(this).text());
-            $(this).addClass(replace_symbols($(this).text()));
+            var url = github_api + search + query + search_details + github_repo;
+            var accept_header = "application/vnd.github.v3.text-match+json";
+
+            $.ajax(url, {headers: {Accept: accept_header}}).done(function(data) {
+                display_search_results(data);
+            });
+        }
+
+        if (ditto.github_username == null && ditto.github_repo == null) {
+            alert("You have not set ditto.github_username and ditto.github_repo!");
+        } else if (ditto.github_username == null) {
+            alert("You have not set ditto.github_username!");
+        } else if (ditto.github_repo == null) {
+            alert("You have not set ditto.github_repo!");
+        }
+    }
+
+    function searchbar_listener(event) {
+        if (event.which === 13) {  // when user presses ENTER in search bar
+            var q = $("input[name=" + ditto.search_name.selector + "]").val();
+            if (q !== "") {
+                location.hash = "#search=" + q;
+            } else {
+                alert("Error! Empty search query!");
+            }
+        }
+    }
+
+    function replace_symbols(text) {
+        // replace symbols with underscore
+        return text.replace(/[&\/\\#,+=()$~%.'":*?<>{}\ \]\[]/g, "_");
+    }
+
+    function li_create_linkage(li_tag, header_level) {
+        // add custom id and class attributes
+        html_safe_tag = replace_symbols(li_tag.text());
+        li_tag.attr("id", html_safe_tag);
+        li_tag.attr("class", "link");
+
+        // add click listener - on click scroll to relevant header section
+        $(ditto.content_id.selector + " li#" + li_tag.attr("id")).click(function() {
+            // scroll to relevant section
+            var header = $(
+                    ditto.content_id + " h" + header_level + "." + li_tag.attr("id")
+                    );
+            $('html, body').animate({
+                scrollTop: header.offset().top
+            }, 200);
+
+            // highlight the relevant section
+            original_color = header.css("color");
+            header.animate({ color: "#ED1C24", }, 500, function() {
+                // revert back to orig color
+                $(this).animate({color: original_color}, 2500);
+            });
         });
+    }
 
-        // parse and set links between li and h2
-        $(ditto.content_id + ' ul li').map(function() {
-            for (var j = 0; j < headers.length; j++) {
-                if (headers[j] === $(this).text()) {
-                    li_create_linkage($(this), i);
+    function create_page_anchors() {
+        // create page anchors by matching li's to headers
+        // if there is a match, create click listeners
+        // and scroll to relevant sections
+
+        // go through header level 2 and 3
+        for (var i = 2; i <= 4; i++) {
+            // parse all headers
+            var headers = [];
+            $(ditto.content_id.selector + ' h' + i).map(function() {
+                headers.push($(this).text());
+                $(this).addClass(replace_symbols($(this).text()));
+            });
+
+            // parse and set links between li and h2
+            $(ditto.content_id.selector + ' ul li').map(function() {
+                for (var j = 0; j < headers.length; j++) {
+                    if (headers[j] === $(this).text()) {
+                        li_create_linkage($(this), i);
+                    }
+                }
+            });
+        }
+    }
+
+    function normalize_paths() {
+        // images
+        ditto.content_id.find("img").map(function() {
+            var src = $(this).attr("src").replace("./", "");
+            if ($(this).attr("src").slice(0, 5) !== "http") {
+                var url = location.hash.replace("#", "");
+
+                // split and extract base dir
+                url = url.split("/");
+                var base_dir = url.slice(0, url.length - 1).join("/");
+
+                // normalize the path (i.e. make it absolute)
+                if (base_dir) {
+                    $(this).attr("src", base_dir + "/" + src);
+                } else {
+                    $(this).attr("src", src);
                 }
             }
         });
+
     }
-}
 
-function normalize_paths() {
-    // images
-    $(ditto.content_id + " img").map(function() {
-        var src = $(this).attr("src").replace("./", "");
-        if ($(this).attr("src").slice(0, 5) !== "http") {
-            var url = location.hash.replace("#", "");
+    function show_error(err_msg) {
+        ditto.error_id.html(err_msg);
+        ditto.error_id.show();
+    }
 
-            // split and extract base dir
-            url = url.split("/");
-            var base_dir = url.slice(0, url.length - 1).join("/");
+    function hide_errors() {
+        ditto.error_id.hide();
+    }
 
-            // normalize the path (i.e. make it absolute)
-            if (base_dir) {
-                $(this).attr("src", base_dir + "/" + src);
-            } else {
-                $(this).attr("src", src);
+    function show_loading() {
+        ditto.loading_id.show();
+        ditto.content_id.html("");  // clear content
+
+        // infinite loop until clearInterval() is called on loading
+        ditto.loading_interval = setInterval(function() {
+            ditto.loading_id.fadeIn(1000).fadeOut(1000);
+        }, 2000);
+
+    }
+
+    function stop_loading() {
+        clearInterval(ditto.loading_interval);
+        ditto.loading_id.hide();
+    }
+
+    function escape_github_badges(data) {
+        $("img").map(function() {
+            var ignore_list = [
+                "travis-ci.org",
+                "coveralls.io"
+            ];
+            var src = $(this).attr("src");
+
+            var base_url = src.split("/");
+            var protocol = base_url[0];
+            var host = base_url[2];
+
+            if ($.inArray(host, ignore_list) >= 0) {
+                $(this).attr("class", "github_badges");
             }
-        }
-    });
-
-}
-
-function show_error(err_msg) {
-    $(ditto.error_id).html(err_msg);
-    $(ditto.error_id).show();
-}
-
-function show_loading() {
-    $(ditto.loading_id).show();
-    $(ditto.content_id).html("");  // clear content
-
-    // infinite loop until clearInterval() is called on loading
-    var loading = setInterval(function() {
-        $(ditto.loading_id).fadeIn(1000).fadeOut(1000);
-    }, 2000);
-
-    return loading;
-}
-
-function escape_github_badges(data) {
-    $("img").map(function() {
-        var ignore_list = [
-            "travis-ci.org",
-            "coveralls.io"
-        ];
-        var src = $(this).attr("src");
-
-        var base_url = src.split("/");
-        var protocol = base_url[0];
-        var host = base_url[2];
-
-        if ($.inArray(host, ignore_list) >= 0) {
-            $(this).attr("class", "github_badges");
-        }
-    });
-    return data;
-}
-
-function page_getter() {
-    var path = location.hash.replace("#", "./");
-
-    // default page if hash is empty
-    var current_page = location.pathname.split("/").pop();
-    if (current_page === "index.html") {
-        path = location.pathname.replace("index.html", ditto.index);
-        normalize_paths();
-
-    } else if (path === "") {
-        path = window.location + ditto.index;
-        normalize_paths();
-
-    } else {
-        path = path + ".md";
-
+        });
+        return data;
     }
 
-    // otherwise get the markdown and render it
-    var loading = show_loading();
-    $.get(path , function(data) {
-        $(ditto.error_id).hide();
+    function page_getter() {
+        var path = location.hash.replace("#", "./");
+
+        // default page if hash is empty
+        var current_page = location.pathname.split("/").pop();
+        if (current_page === "index.html") {
+            path = location.pathname.replace("index.html", ditto.index);
+            normalize_paths();
+
+        } else if (path === "") {
+            path = window.location + ditto.index;
+            normalize_paths();
+
+        } else {
+            path = path + ".md";
+
+        }
+
+        // otherwise get the markdown and render it
+        show_loading();
+        var cache_value = cache.fetch(path);
+
+        if (cache.present && cache_value) {
+            compile_into_dom(path, cache_value);
+        } else {
+            $.get(path, function(data) {
+                compile_into_dom(path, data);
+            }).fail(function() {
+                show_error("Opps! ... File not found!");
+            })
+        }
+    }
+
+    function compile_into_dom(path, data) {
+        hide_errors();
         data = marked(data);
-        $(ditto.content_id).html(data);
+        ditto.content_id.html(data);
+        stop_loading();
+        cache.store(path, data);
         escape_github_badges(data);
 
         normalize_paths();
@@ -355,27 +393,22 @@ function page_getter() {
                 hljs.highlightBlock(block);
             }
         });
-
-    }).fail(function() {
-        show_error("Opps! ... File not found!");
-
-    }).always(function() {
-        clearInterval(loading);
-        $(ditto.loading_id).hide();
-
-    });
-}
-
-function router() {
-    var hash = location.hash;
-
-    if (hash.slice(1, 7) !== "search") {
-        page_getter();
-
-    } else {
-        if (ditto.searchbar) {
-            github_search(hash.replace("#search=", ""));
-        }
-
     }
-}
+
+    function router() {
+        var hash = location.hash;
+
+        if (hash.slice(1, 7) !== "search") {
+            page_getter();
+
+        } else {
+            if (ditto.searchbar) {
+                github_search(hash.replace("#search=", ""));
+            }
+
+        }
+    }
+
+    window.ditto = ditto;
+
+});


### PR DESCRIPTION
I had to re-indent your code to match the new wrapper. Everything was global before so I placed it inside a function executed once the dom has loaded. Added local storage caching to make the transition between fragments a little snappier. Also, you were making lots of jQuery calls for the exact same element (see l65 and l66 in the old code). I cached all these elements and replaced them elsewhere. Wherever you were using the string representation I switched it to ```ditto.el.selector```. It might be a good shout to replace all the ```ditto.el_id``` with just ```ditto.el``` too.