### PR TITLE
add folder and file extension config

### DIFF
--- a/docs/how_do_i_use_ditto.md
+++ b/docs/how_do_i_use_ditto.md
@@ -63,8 +63,8 @@ snippet and save it as `index.html`
         <script>
             $(function($) {
                 // essential settings
-                ditto.index = "README.md",
-                ditto.sidebar_file = "sidebar.md",
+                ditto.index = "README",
+                ditto.sidebar_file = "sidebar",
 
                 // optional settings if you want github search
                 ditto.github_username = null;   // <------- EDIT ME!!
@@ -92,25 +92,30 @@ Edit:
 
 as you see fit.
 
+Also, you can specify a folder other than `docs`, and also a different file extension than `.md`
+
+- `ditto.base_dir`
+- `ditto.file_extension`
+
 
 ## sidebar.md
 In the `sidebar.md` file you can create links to documentation you wish to list
 (just as you would in markdown). You have to list them in the form:
 
-    #folder_containing_docs/file_name_without_extension
+    #file_name_without_extension
 
 For example:
 
-    - [Documentation 1](#docs/document_1)
-    - [Documentation 2](#docs/document_2)
-    - [Documentation 3](#docs/document_3)
+    - [Documentation 1](#document_1)
+    - [Documentation 2](#document_2)
+    - [Documentation 3](#document_3)
 
 If you want the GitHub search bar enter the following in the same file:
 
     [ditto:searchbar]
 
 **IMPORTANT NOTE**:
-- Add `#` infront of `docs`, where `docs` is the folder where `document_1.md` resides
+- Add `#` infront of `document_1.md` to ensure it is found in the docs folder
 - Also ___DO NOT___ INCLUDE THE FILE EXTENSION AT THE END!
 
 ## README.md

--- a/docs/how_does_it_work.md
+++ b/docs/how_does_it_work.md
@@ -15,14 +15,14 @@ differently by you otherwise).
 
 Documentation defined in `sidebar.md` should be of the form:
 
-    #folder_containing_docs/file_name_without_extension
+    #file_name_without_extension
 
 
 For example:
 
-    - #docs/document_1
-    - #docs/document_2
-    - #docs/document_3
+    - #document_1
+    - #document_2
+    - #document_3
 
 When you click on the link, the hash is parsed and modified in such a way it
 converts it back to the file location where the documentation is:
@@ -30,7 +30,7 @@ converts it back to the file location where the documentation is:
 
     From:                         To:
 
-    #docs/document_1 -----------> docs/document_1.md
+    #document_1 ----------------> docs/document_1.md
 
 
 `jQuery` then launches a GET request to the server requesting the markdown file

--- a/index.html
+++ b/index.html
@@ -34,8 +34,8 @@
     <script>
         $(function($) {
           // essential settings
-          ditto.index = "README.md",
-          ditto.sidebar_file = "sidebar.md",
+          ditto.index = "README",
+          ditto.sidebar_file = "sidebar",
 
           // optional settings if you want github search
           ditto.github_username = "chutsu";   // <------- EDIT ME!!

--- a/js/ditto.js
+++ b/js/ditto.js
@@ -27,6 +27,10 @@ $(function($) {
     github_username: null,
     github_repo: null,
 
+    // Base directory
+    base_dir: "docs",
+    file_extension: ".md",
+
     // initialize function
     run: initialize
   };
@@ -56,7 +60,7 @@ $(function($) {
   }
 
   function init_sidebar_section() {
-    $.get(ditto.sidebar_file, function(data) {
+    $.get(ditto.sidebar_file + ditto.file_extension, function(data) {
       ditto.sidebar_id.html(marked(data));
 
       if (ditto.searchbar) {
@@ -88,10 +92,10 @@ $(function($) {
         var hash = location.hash.replace("#", "/");
 
         if (hash === "") {
-          hash = "/" + ditto.index.replace(".md", "");
+          hash = "/" + ditto.index + ditto.file_extension;
         }
 
-        window.open(ditto.base_url + hash + ".md");
+        window.open(ditto.base_url + hash + ditto.file_extension);
         // open is better than redirecting, as the previous page history
         // with redirect is a bit messed up
       });
@@ -141,8 +145,8 @@ $(function($) {
     for (var i = 0; i < matches.length; i++) {
       var url = matches[i].path;
 
-      if (url !== ditto.sidebar_file) {
-        var hash = "#" + url.replace(".md", "");
+      if (url !== ditto.sidebar_file + ditto.file_extension) {
+        var hash = "#" + url.replace(ditto.file_extension, "");
         var path = window.location.origin+ "/" + hash;
 
         // html += "<li>";
@@ -173,7 +177,7 @@ $(function($) {
 
     ditto.content_id.html(results_html);
     $(ditto.search_results_class + " .link").click(function(){
-      var destination = "#" + $(this).html().replace(".md", "");
+      var destination = "#" + $(this).html().replace(ditto.file_extension, "");
       location.hash = destination;
     });
   }
@@ -272,7 +276,7 @@ $(function($) {
     ditto.content_id.find("img").map(function() {
       var src = $(this).attr("src").replace("./", "");
       if ($(this).attr("src").slice(0, 5) !== "http") {
-        var url = location.hash.replace("#", "");
+        var url = location.hash.replace("#", ditto.base_dir + "/");
 
         // split and extract base dir
         url = url.split("/");
@@ -335,20 +339,20 @@ $(function($) {
 
   function page_getter() {
     window.scrollTo(0, 0);
-    var path = location.hash.replace("#", "./");
+    var path = location.hash.replace("#", "./" + ditto.base_dir + "/");
 
     // default page if hash is empty
     var current_page = location.pathname.split("/").pop();
     if (current_page === "index.html") {
-      path = location.pathname.replace("index.html", ditto.index);
+      path = location.pathname.replace("index.html", ditto.index + ditto.file_extension);
       normalize_paths();
 
     } else if (path === "") {
-      path = window.location + ditto.index;
+      path = window.location + ditto.index + ditto.file_extension;
       normalize_paths();
 
     } else {
-      path = path + ".md";
+      path = path + ditto.file_extension;
 
     }
 

--- a/sidebar.md
+++ b/sidebar.md
@@ -6,10 +6,10 @@ version 0.12
 [ditto:searchbar]
 
 ## FAQ
-- [How do I use ditto?](#docs/how_do_i_use_ditto)
-- [How does it work?](#docs/how_does_it_work)
-- [Why use ditto?](#docs/why_use_ditto)
-- [How do I run ditto locally?](#docs/how_do_i_run_ditto_locally)
+- [How do I use ditto?](#how_do_i_use_ditto)
+- [How does it work?](#how_does_it_work)
+- [Why use ditto?](#why_use_ditto)
+- [How do I run ditto locally?](#how_do_i_run_ditto_locally)
 
 ## Projects that use ditto
 - [playground](http://chutsu.github.io/playground)

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,8 +34,8 @@
     <script>
         $(function($) {
           // essential settings
-          ditto.index = "README.md",
-          ditto.sidebar_file = "sidebar.md",
+          ditto.index = "README",
+          ditto.sidebar_file = "sidebar",
 
           // optional settings if you want github search
           ditto.github_username = null;   // <------- EDIT ME!!

--- a/templates/sidebar.md
+++ b/templates/sidebar.md
@@ -6,5 +6,5 @@ version 0.1
 [ditto:searchbar]
 
 ## Header 2
-- [Page1](#docs/page1)
-- [Page2](#docs/page2)
+- [Page1](#page1)
+- [Page2](#page2)


### PR DESCRIPTION
I thought it would make this way better to have a configurable docs folder and file extension. This way, the other markdown extensions (`.mdown`, `.markdown`) can be used if preferred.

Also, and this is the biggie, it makes cleaner URLs without the docs folder present in the address bar. If a dev forgets to hide the contents of that folder, or forgets to stop directory listing, it can break the experience getting a plain markdown file, or folder listing by going dorectly to the folder.

I reckon this does need some checking to make sure I updated the docs correctly. I have surely missed something.

I won't be offended if you decide not to go this route.